### PR TITLE
Fixed empty device model in DeviceCreated event.

### DIFF
--- a/src/Events/DeviceCreated.php
+++ b/src/Events/DeviceCreated.php
@@ -3,9 +3,13 @@
 namespace Lab404\AuthChecker\Events;
 
 use Lab404\AuthChecker\Models\Device;
+use Illuminate\Queue\SerializesModels;
 
 class DeviceCreated
 {
+
+    use SerializesModels;
+
     /** @var Device */
     public $device;
 

--- a/src/Services/AuthChecker.php
+++ b/src/Services/AuthChecker.php
@@ -139,7 +139,7 @@ class AuthChecker
 
         $device->save();
 
-        event(DeviceCreated::class);
+        event(new DeviceCreated($device));
 
         return $device;
     }


### PR DESCRIPTION
Fixed empty Device model being passed to DeviceCreated event.