### PR TITLE
Fix lazy loading issue

### DIFF
--- a/src/Services/AuthChecker.php
+++ b/src/Services/AuthChecker.php
@@ -188,6 +188,8 @@ class AuthChecker
         $attributes = is_null($attributes) ? $this->getDeviceMatchingAttributesConfig() : $attributes;
         $matches = 0;
 
+        $device->loadMissing('login');
+
         if (in_array('platform', $attributes)) {
             $matches += $device->platform === $agent->platform();
         }

--- a/src/Services/AuthChecker.php
+++ b/src/Services/AuthChecker.php
@@ -167,6 +167,8 @@ class AuthChecker
     {
         $throttle = $this->getLoginThrottleConfig();
 
+        $device->loadMissing('login');
+
         if ($throttle === 0 || is_null($device->login)) {
             return true;
         }


### PR DESCRIPTION
If there is more than one device logged, an error appears on login:

![image](https://user-images.githubusercontent.com/37669560/165001176-52d45335-2475-4abb-b6b4-5110e88c2d58.png)

This PR fixes the issue.