### PR TITLE
Ignore `.idea` & `.vscode` IDE folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.idea
+/.vscode
 /vendor/
 composer.lock
 .phpunit.result.cache


### PR DESCRIPTION
Faced the issue with untracked IDE files when working with the package.
This PR adds these missing `.gitignore` entries.