### PR TITLE
⬆️ Bump dependencies to Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,13 @@
     "laravel-plugin"
   ],
   "require": {
-    "php": "^8.0",
-    "laravel/framework": "^9.0|^10.0",
+    "php": "^8.2",
+    "laravel/framework": "^11.0",
     "jenssegers/agent": "^2.6"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5|^9.5",
-    "orchestra/testbench": "^7.0",
-    "orchestra/database": "^7.0"
+    "phpunit/phpunit": "^11.0.1",
+    "orchestra/testbench": "^9.0"
   },
   "license": "MIT",
   "authors": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,29 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Laravel Auth Checker Test Suite">
-            <file>tests/AuthCheckerTest.php</file>
-            <file>tests/EventsTest.php</file>
-            <file>tests/HasLoginsAndDevicesTest.php</file>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.1/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Laravel Auth Checker Test Suite">
+      <file>tests/AuthCheckerTest.php</file>
+      <file>tests/EventsTest.php</file>
+      <file>tests/HasLoginsAndDevicesTest.php</file>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,6 @@ namespace Lab404\Tests;
 
 use Lab404\AuthChecker\AuthCheckerServiceProvider;
 use Lab404\Tests\Stubs\Models\User;
-use Orchestra\Database\ConsoleServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -52,7 +51,6 @@ class TestCase extends \Orchestra\Testbench\TestCase
     protected function getPackageProviders($app)
     {
         return [
-            ConsoleServiceProvider::class,
             AuthCheckerServiceProvider::class,
         ];
     }


### PR DESCRIPTION
- Drop orchestra/database. Not compatible.
- Fix #33.